### PR TITLE
chore: track pre-commit version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# NOTE: this is intended for Renovate/Dependabot to notify of updates
+pre-commit==4.1.0
+# If the version is bumped, please update the `pre_commit_version` in the action.yml
+# and bump the action to a new version to release the change.


### PR DESCRIPTION
This should allow renovate to open PRs for updates and notify of changes.